### PR TITLE
Take device pixel ratio into account when scaling

### DIFF
--- a/js/renderer.ts
+++ b/js/renderer.ts
@@ -852,8 +852,9 @@ export abstract class ReactUiBase extends Component implements ReactComp {
         const s = bottomRight[0] - topLeft[0];
         this.object.setScalingLocal([s, s, s]);
         /* Convert from yoga units to 0-1 */
-        this.width = this.engine.canvas.clientWidth;
-        this.height = this.engine.canvas.clientHeight;
+        const dpr = window.devicePixelRatio ?? 1;
+        this.width = this.engine.canvas.clientWidth * dpr;
+        this.height = this.engine.canvas.clientHeight * dpr;
         this.scaling = [1 / this.width, 1 / this.width];
         this.object.setPositionLocal(topLeft);
 


### PR DESCRIPTION
When calculating the scaling, we should take the device pixel ratio into account. This makes sure the UI is rendered correctly on mobile devices. 

The first screenshot below shows the UI on mobile before this change. The UI uses the clientWidth and clientHeight of the canvas. This is 360x599 on my phone. The game itself is scaled correctly. With the pixel ratio of 3 this counts up the width and the height causing enough pixels to be rendered for a sharp image. 

The second screenshot is taken with this change. This now renders in exact the same dimensions as it would on desktop, making all the other calculations also work correct. 

![Snag_29b45d0c](https://github.com/user-attachments/assets/bf130504-68e1-4538-afeb-58bfc5e4c507)
![Snag_29b4677c](https://github.com/user-attachments/assets/4535789b-53cc-48b1-afd7-eb8046887218)
