### PR TITLE
Correct scaling

### DIFF
--- a/js/renderer.ts
+++ b/js/renderer.ts
@@ -806,6 +806,19 @@ export enum UISpace {
     Screen = 1,
 }
 
+export enum ScalingType {
+    /**
+     * The sizes absolute to the screen size. A pixel in the UI is a pixel on screen.
+     * This is the default.
+     */
+    Absolute = 0,
+
+    /**
+     * The height of the UI will be fixed to the value set in the `manualHeight` property.
+     */
+    FixedHeight = 1,
+}
+
 export abstract class ReactUiBase extends Component implements ReactComp {
     static TypeName = 'react-ui-base';
 
@@ -830,13 +843,11 @@ export abstract class ReactUiBase extends Component implements ReactComp {
     @property.int(100)
     height = 100;
 
-    /**
-     * If set to 'true', the UI will be scaled automatically.
-     * If set to 'false', 'manualHeight' is used instead, and the UI will scale proportionally to screen's height,
-     * always remaining the same relative size regardless of the resolution changes.
-     */
-    @property.bool(true)
-    automatic = true;
+    @property.enum(
+        Object.keys(ScalingType).filter((e) => isNaN(Number(e))),
+        ScalingType.Absolute
+    )
+    scalingMode: ScalingType = ScalingType.Absolute;
 
     @property.float(1080)
     manualHeight = 1080;
@@ -847,7 +858,12 @@ export abstract class ReactUiBase extends Component implements ReactComp {
     dpr = 1;
 
     get pixelSizeAdjustment() {
-        return this.automatic ? 1 : this.manualHeight / this.engine.canvas.height;
+        switch (this.scalingMode) {
+            case ScalingType.FixedHeight:
+                return this.manualHeight / this.engine.canvas.height;
+            default:
+                return 1;
+        }
     }
 
     static onRegister(engine: WonderlandEngine) {

--- a/js/renderer.ts
+++ b/js/renderer.ts
@@ -830,6 +830,29 @@ export abstract class ReactUiBase extends Component implements ReactComp {
     @property.int(100)
     height = 100;
 
+    /**
+     * If set to 'true', the UI will be scaled automatically.
+     * If set to 'false', 'manualHeight' is used instead, and the UI will scale proportionally to screen's height,
+     * always remaining the same relative size regardless of the resolution changes.
+     */
+    @property.bool(true)
+    automatic = true;
+
+    @property.float(1080)
+    manualHeight = 1080;
+
+    /**
+     * Device pixel ratio, defaults to 1. Used on mobile/tablet devices to scale.
+     */
+    dpr = 1;
+
+    get pixelSizeAdjustment() {
+        const height = this.engine.canvas.height;
+        // if (height < minimumHeight) return minimumHeight / height;
+        // if (height > maximumHeight) return maximumHeight / height;
+        return this.automatic ? 1 : this.manualHeight / height;
+    }
+
     static onRegister(engine: WonderlandEngine) {
         engine.registerComponent(CursorTarget);
     }
@@ -852,12 +875,13 @@ export abstract class ReactUiBase extends Component implements ReactComp {
         const s = bottomRight[0] - topLeft[0];
         this.object.setScalingLocal([s, s, s]);
         /* Convert from yoga units to 0-1 */
-        const dpr = window.devicePixelRatio ?? 1;
-        this.width = this.engine.canvas.clientWidth * dpr;
-        this.height = this.engine.canvas.clientHeight * dpr;
+        this.dpr = window.devicePixelRatio ?? 1;
+        this.width = this.engine.canvas.clientWidth * this.pixelSizeAdjustment * this.dpr;
+        this.height = this.engine.canvas.clientHeight * this.pixelSizeAdjustment * this.dpr;
         this.scaling = [1 / this.width, 1 / this.width];
         this.object.setPositionLocal(topLeft);
-
+        this.onDeactivate();
+        this.onActivate();
         this.needsUpdate = true;
         this.viewportChanged = true;
     };
@@ -1079,8 +1103,8 @@ export abstract class ReactUiBase extends Component implements ReactComp {
     onPointerMove(e: PointerEvent) {
         /* Don't care about secondary pointers */
         if (!e.isPrimary) return null;
-        const x = e.clientX;
-        const y = e.clientY;
+        const x = e.clientX * this.pixelSizeAdjustment * this.dpr;
+        const y = e.clientY * this.pixelSizeAdjustment * this.dpr;
         this.onMove({x, y, e});
     }
 
@@ -1130,8 +1154,8 @@ export abstract class ReactUiBase extends Component implements ReactComp {
     };
 
     onPointerClick(e: PointerEvent) {
-        const x = e.clientX;
-        const y = e.clientY;
+        const x = e.clientX * this.pixelSizeAdjustment * this.dpr;
+        const y = e.clientY * this.pixelSizeAdjustment * this.dpr;
         this.onClick({x, y, e});
     }
 
@@ -1139,8 +1163,8 @@ export abstract class ReactUiBase extends Component implements ReactComp {
     onPointerDown(e: PointerEvent): NodeWrapper | null {
         /* Don't care about secondary pointers or non-left clicks */
         if (!e.isPrimary || e.button !== 0) return null;
-        const x = e.clientX;
-        const y = e.clientY;
+        const x = e.clientX * this.pixelSizeAdjustment * this.dpr;
+        const y = e.clientY * this.pixelSizeAdjustment * this.dpr;
         return this.onDown({x, y, e});
     }
 
@@ -1148,8 +1172,8 @@ export abstract class ReactUiBase extends Component implements ReactComp {
     onPointerUp(e: PointerEvent): NodeWrapper | null {
         /* Don't care about secondary pointers or non-left clicks */
         if (!e.isPrimary || e.button !== 0) return null;
-        const x = e.clientX;
-        const y = e.clientY;
+        const x = e.clientX * this.pixelSizeAdjustment * this.dpr;
+        const y = e.clientY * this.pixelSizeAdjustment * this.dpr;
         return this.onUp({x, y, e});
     }
 

--- a/js/renderer.ts
+++ b/js/renderer.ts
@@ -852,8 +852,9 @@ export abstract class ReactUiBase extends Component implements ReactComp {
         const s = bottomRight[0] - topLeft[0];
         this.object.setScalingLocal([s, s, s]);
         /* Convert from yoga units to 0-1 */
-        this.width = this.engine.canvas.clientWidth;
-        this.height = this.engine.canvas.clientHeight;
+        const dpr = window.devicePixelRatio ?? 1;
+        this.width = this.engine.canvas.clientWidth * dpr;
+        this.height = this.engine.canvas.clientHeight * dpr;
         this.scaling = [1 / this.width, 1 / this.width];
         this.object.setPositionLocal(topLeft);
 

--- a/js/renderer.ts
+++ b/js/renderer.ts
@@ -847,10 +847,7 @@ export abstract class ReactUiBase extends Component implements ReactComp {
     dpr = 1;
 
     get pixelSizeAdjustment() {
-        const height = this.engine.canvas.height;
-        // if (height < minimumHeight) return minimumHeight / height;
-        // if (height > maximumHeight) return maximumHeight / height;
-        return this.automatic ? 1 : this.manualHeight / height;
+        return this.automatic ? 1 : this.manualHeight / this.engine.canvas.height;
     }
 
     static onRegister(engine: WonderlandEngine) {
@@ -880,8 +877,6 @@ export abstract class ReactUiBase extends Component implements ReactComp {
         this.height = this.engine.canvas.clientHeight * this.pixelSizeAdjustment * this.dpr;
         this.scaling = [1 / this.width, 1 / this.width];
         this.object.setPositionLocal(topLeft);
-        this.onDeactivate();
-        this.onActivate();
         this.needsUpdate = true;
         this.viewportChanged = true;
     };

--- a/js/renderer.ts
+++ b/js/renderer.ts
@@ -872,9 +872,9 @@ export abstract class ReactUiBase extends Component implements ReactComp {
         const s = bottomRight[0] - topLeft[0];
         this.object.setScalingLocal([s, s, s]);
         /* Convert from yoga units to 0-1 */
-        this.dpr = window.devicePixelRatio ?? 1;
-        this.width = this.engine.canvas.clientWidth * this.pixelSizeAdjustment * this.dpr;
-        this.height = this.engine.canvas.clientHeight * this.pixelSizeAdjustment * this.dpr;
+        this.dpr = window.devicePixelRatio;
+        this.width = this._dpiAdjust(this.engine.canvas.clientWidth);
+        this.height = this._dpiAdjust(this.engine.canvas.clientHeight);
         this.scaling = [1 / this.width, 1 / this.width];
         this.object.setPositionLocal(topLeft);
         this.needsUpdate = true;
@@ -1098,8 +1098,8 @@ export abstract class ReactUiBase extends Component implements ReactComp {
     onPointerMove(e: PointerEvent) {
         /* Don't care about secondary pointers */
         if (!e.isPrimary) return null;
-        const x = e.clientX * this.pixelSizeAdjustment * this.dpr;
-        const y = e.clientY * this.pixelSizeAdjustment * this.dpr;
+        const x = this._dpiAdjust(e.clientX);
+        const y = this._dpiAdjust(e.clientY);
         this.onMove({x, y, e});
     }
 
@@ -1149,8 +1149,8 @@ export abstract class ReactUiBase extends Component implements ReactComp {
     };
 
     onPointerClick(e: PointerEvent) {
-        const x = e.clientX * this.pixelSizeAdjustment * this.dpr;
-        const y = e.clientY * this.pixelSizeAdjustment * this.dpr;
+        const x = this._dpiAdjust(e.clientX);
+        const y = this._dpiAdjust(e.clientY);
         this.onClick({x, y, e});
     }
 
@@ -1158,8 +1158,8 @@ export abstract class ReactUiBase extends Component implements ReactComp {
     onPointerDown(e: PointerEvent): NodeWrapper | null {
         /* Don't care about secondary pointers or non-left clicks */
         if (!e.isPrimary || e.button !== 0) return null;
-        const x = e.clientX * this.pixelSizeAdjustment * this.dpr;
-        const y = e.clientY * this.pixelSizeAdjustment * this.dpr;
+        const x = this._dpiAdjust(e.clientX);
+        const y = this._dpiAdjust(e.clientY);
         return this.onDown({x, y, e});
     }
 
@@ -1167,14 +1167,18 @@ export abstract class ReactUiBase extends Component implements ReactComp {
     onPointerUp(e: PointerEvent): NodeWrapper | null {
         /* Don't care about secondary pointers or non-left clicks */
         if (!e.isPrimary || e.button !== 0) return null;
-        const x = e.clientX * this.pixelSizeAdjustment * this.dpr;
-        const y = e.clientY * this.pixelSizeAdjustment * this.dpr;
+        const x = this._dpiAdjust(e.clientX);
+        const y = this._dpiAdjust(e.clientY);
         return this.onUp({x, y, e});
     }
 
     renderCallback() {
         // FIXME: Never called
         this.needsUpdate = true;
+    }
+
+    private _dpiAdjust(value: number) {
+        return value * this.pixelSizeAdjustment * this.dpr;
     }
 
     abstract render(): ReactNode;


### PR DESCRIPTION
Use DPR for correct scaling on mobile devices and tablets. 
Add a feature to disable automatic scaling and use a fixed scale so a UI looks the same on all devices.

---

**Bit of background for these changes**

There could be a very big difference between the ClientHeight/ClientWidth of and the normal height and width of the canvas on devices. The Samsung S24 has a DPR of 3. This means that there is a factor 3 difference between the two. Because the UI uses the client dimensions to render the UI was scaled up 3x resulting in the buttons going outside of the screen. By using the DPR the rendering is similar between desktop and device when the canvas is the same width in pixels.  

However, this does not mean that the UI fits. A normal desktop resolution might be 1080 pixels in height, while an iPhone 14 Pro Max has a height of almost 2800 pixels. The second feature that is added allows the height in pixels to be defined by the app—for example 900 pixels. If the UI then contains a panel of 450 pixels height is half of that height when the screen is 900 pixels. But when the screen is 2800 pixels it is automatically scaled up also to be half of that resolution. Thus the UI looks similar on all resolutions. Without the loss of quality, because it is rendered at the correct resolution.  