### PR TITLE
Fix NaN + add Z scale on meshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to the *Wonderland React UI* library will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.1] - 2024-11-27
+## [???]
+
+### Change
+
+- Catch 2 possible NaN values coming from getComputedWidth and getComputedHeight. Because of this, the scale becomes NaN initially. Any code that depends on that might break.
+- Add Z-scale for meshes. Scale is almost the same for X and Y. Z is not used in 2D UIs, but when the value is set to 1 for a mesh the meshes can get skewed/warped. This was not noticeable until now because only planes were rendered. I set the Z equal to the X scale for now.
+
+## [0.2.2] - 2024-11-27
 
 ### Add
 

--- a/js/renderer.ts
+++ b/js/renderer.ts
@@ -366,8 +366,16 @@ function applyLayoutToSceneGraph(n: NodeWrapper, context: Context, force?: boole
                 return child;
             })();
 
-        const sw = n.node.getComputedWidth() * context.comp.scaling[0];
-        const sh = n.node.getComputedHeight() * context.comp.scaling[1];
+        let sw = n.node.getComputedWidth() * context.comp.scaling[0];
+        let sh = n.node.getComputedHeight() * context.comp.scaling[1];
+
+        // there is a change that on the first time the code is executed getComputedWidth
+        // and getComputedHeight return NaN. In that case we set the values to 0 to prevent
+        // any more issues.
+        if (isNaN(sw) || isNaN(sh)) {
+            sw = 0;
+            sh = 0;
+        }
         const centerX = 0.5 * sw;
         const centerY = -0.5 * sh;
 
@@ -463,7 +471,7 @@ function applyLayoutToSceneGraph(n: NodeWrapper, context: Context, force?: boole
         } else {
             /* Planes are diameter of 2 */
             child.setPositionLocal([centerX, centerY, Z_INC + (n.props.z ?? 0)]);
-            child.setScalingLocal([0.5 * sw, 0.5 * sh, 1]);
+            child.setScalingLocal([0.5 * sw, 0.5 * sh, 0.5 * sw]);
         }
         m.mesh = n.props.mesh ?? mesh;
     }

--- a/js/renderer.ts
+++ b/js/renderer.ts
@@ -471,7 +471,12 @@ function applyLayoutToSceneGraph(n: NodeWrapper, context: Context, force?: boole
         } else {
             /* Planes are diameter of 2 */
             child.setPositionLocal([centerX, centerY, Z_INC + (n.props.z ?? 0)]);
-            child.setScalingLocal([0.5 * sw, 0.5 * sh, 0.5 * sw]);
+            child.setScalingLocal([
+                0.5 * sw,
+                0.5 * sh,
+                // if there's a z value set we're not scaling the z value.
+                n.props.z === undefined ? 0.5 * sw : 1,
+            ]);
         }
         m.mesh = n.props.mesh ?? mesh;
     }
@@ -854,6 +859,9 @@ export enum ScalingType {
     FixedHeightLimitedWidth = 2,
 }
 
+const tempPos = [0, 0, 0];
+const tempScale = [0, 0, 0];
+
 export abstract class ReactUiBase extends Component implements ReactComp {
     static TypeName = 'react-ui-base';
 
@@ -1016,11 +1024,12 @@ export abstract class ReactUiBase extends Component implements ReactComp {
     callbacks: Record<string, any> = {};
 
     getCursorPosition(c: Cursor): [number, number] {
-        const pos = [0, 0, 0];
-        const scale = [0, 0, 0];
-        this.object.transformPointInverseWorld(pos, c.cursorPos);
-        this.object.getScalingWorld(scale);
-        return [pos[0] / this.scaling[0] / scale[0], -pos[1] / this.scaling[1] / scale[1]];
+        this.object.transformPointInverseWorld(tempPos, c.cursorPos);
+        this.object.getScalingWorld(tempScale);
+        return [
+            tempPos[0] / this.scaling[0] / tempScale[0],
+            -tempPos[1] / this.scaling[1] / tempScale[1],
+        ];
     }
 
     override onActivate(): void {


### PR DESCRIPTION
Catch 2 possible NaN values coming from getComputedWidth and getComputedHeight. Because of this, the scale becomes NaN initially. Any code that depends on that might break.

Add Z-scale for meshes. Scale is almost the same for X and Y. Z is not used in 2D UIs, but when the value is set to 1 for a mesh the meshes can get skewed/warped. This was not noticeable until now because only planes were rendered. I set the Z equal to the X scale for now. 