### PR TITLE
Fix potential issues with white space and multiple text strings

### DIFF
--- a/packages/react-ui/js/components/Text.tsx
+++ b/packages/react-ui/js/components/Text.tsx
@@ -1,7 +1,7 @@
 import {Object3D} from '@wonderlandengine/api';
 import React, {forwardRef, PropsWithChildren, useContext, useMemo} from 'react';
 import type {TextProps, Color} from '../renderer-types.js';
-import {parseColor} from '../utils.js';
+import {childrenToFlatString, parseColor} from '../utils.js';
 import {
     MaterialContext,
     ThemeContext,
@@ -34,7 +34,7 @@ const tempColor = new Float32Array(4);
  * @param {TextProps & {color?: Color}} props - The text properties
  * @param {Color} [props.color] - Text color. Falls back to theme color or material color
  * @param {Material} [props.material] - Custom material for the text. If not provided, uses cloned text material from context
- * @param {string} [props.text] - Alternative way to provide text content (children takes precedence)
+ * @param {string} [props.text] - Alternative way to provide text content (prioritized over children)
  * @param {React.ReactNode} props.children - Text content to display (converted to string)
  * @param {React.Ref<Object3D>} ref - Forward ref to access the underlying 3D object
  * @returns {React.ReactElement} A 3D text element
@@ -70,7 +70,7 @@ export const Text = forwardRef<
     return React.createElement('text3d', {
         ...props,
         material: mat,
-        text: props.children?.toString() ?? props.text,
+        text: props.text ?? childrenToFlatString(props.children),
         ref: ref,
     });
 });

--- a/packages/react-ui/js/utils.ts
+++ b/packages/react-ui/js/utils.ts
@@ -1,3 +1,5 @@
+import React from 'react';
+
 /**
  * Converts a hexadecimal color string to a Float32Array with RGBA values.
  * Supports multiple hex formats including 3, 6, and 8 character representations.
@@ -109,4 +111,39 @@ export function parseColor(
         return out;
     }
     return hex;
+}
+
+/**
+ * Converts React children into a flat string representation.
+ * Extracts all string and number children, concatenating them into a single string.
+ * Non-string and non-number children (such as React elements) are ignored.
+ *
+ * @example
+ * ```typescript
+ * // Simple text children
+ * childrenToFlatString('Hello'); // Returns 'Hello'
+ *
+ * // Multiple text and number children
+ * childrenToFlatString(['Hello', ' ', 'World']); // Returns 'Hello World'
+ *
+ * // Mixed with React elements (elements are ignored)
+ * childrenToFlatString(['Text', <Component />, 123]); // Returns 'Text123'
+ * ```
+ *
+ * @param {React.ReactNode} children - React children nodes to flatten. Can contain strings, numbers, elements, or fragments.
+ * @returns {string} A concatenated string of all string and number children
+ */
+export function childrenToFlatString(children: React.ReactNode): string {
+    return React.Children.toArray(children)
+        .map((child) => {
+            if (
+                typeof child === 'string' ||
+                typeof child === 'number' ||
+                typeof child === 'bigint'
+            ) {
+                return child;
+            }
+            return ''; // ignore anything else
+        })
+        .join('');
 }


### PR DESCRIPTION
Improve concatenation of strings when used as children of `<text>`

The example below now renders as `A B` instead of `A, ,B` previously. 

```jsx
<Text>
  {'A'} {'B'}
</Text>
```